### PR TITLE
Fix spacing

### DIFF
--- a/content/sections/hero/hero.json
+++ b/content/sections/hero/hero.json
@@ -10,7 +10,7 @@
   },
   "title": "I'm a freelance web engineer.",
   "subtitle": {
-    "prefix": "I handle all of your web development work so",
+    "prefix": "I handle all of your web development work so ",
     "highlight": "you don't have to",
     "suffix": "."
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Overview
This PR just fixes a minor typo. Before, there was no space between the "soyou" in "so you don't have to." Now there is. 

<!--- Describe your changes in detail -->

## Background

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing

<!--- Please describe in detail how to test these changes. -->

## Screenshot(s):
Before: 

<img width="1440" alt="Screen Shot 2023-03-22 at 3 21 10 PM" src="https://user-images.githubusercontent.com/59572865/227059061-957553bf-008d-4316-9081-4cdfd589dcb5.png">

After: 
<img width="1439" alt="Screen Shot 2023-03-22 at 6 15 43 PM" src="https://user-images.githubusercontent.com/59572865/227059497-40e684a1-0541-4a89-8e82-d84401bc47d3.png">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have self-reviewed my code and added comments where relevant.
- [ ] I have updated any relevant documentation.
